### PR TITLE
Add Error/Fallback UI for Failed Content

### DIFF
--- a/app.js
+++ b/app.js
@@ -158,7 +158,8 @@ async function loadConfig() {
             img.onerror = function () {
               img.style.display = 'none';
               const fallback = document.createElement('p');
-              fallback.textContent = 'Image not available';
+              fallback.className = 'error-message';
+              fallback.textContent = 'Image not found';
               wrapper.appendChild(fallback);
             };
             wrapper.appendChild(img);
@@ -178,6 +179,9 @@ async function loadConfig() {
     }
   } catch (error) {
     console.error('Config error:', error);
+    document.getElementById('title').textContent =
+      'Configuration could not be loaded';
+    document.getElementById('title').classList.add('error-message');
   }
 }
 
@@ -420,7 +424,7 @@ function fetchNews(rssUrl, maxItems, cycleSec) {
     .catch(function (error) {
       console.error('News error:', error);
       document.getElementById('news-container').innerHTML =
-        '<p>News unavailable</p>';
+        '<p class="error-message">Feed unavailable</p>';
     });
 }
 

--- a/style.css
+++ b/style.css
@@ -153,6 +153,14 @@ h2 {
   line-height: 1.5;
 }
 
+/* ================= ERROR FALLBACK ================= */
+
+.error-message {
+  color: #ff6b6b;
+  font-style: italic;
+  opacity: 0.9;
+}
+
 /* ================= CYCLING TRANSITIONS ================= */
 
 .cycle-item {


### PR DESCRIPTION
Summary                                                                                                                                
                                                                                                                                         
  Closes #15. When content fails to load, users now see a visible error message instead of blank panels or "Loading..." stuck forever.   

  What changed
<img width="941" height="187" alt="image" src="https://github.com/user-attachments/assets/e7e362c2-4f21-46e1-a437-32fa5fcbe917" />
All errors are still logged to console.error() for debugging.

 Files changed:
`app.js` : Config catch block now updates title with error message; RSS and image fallbacks use .error-message class
`style.css` : New .error-message class: color: #ff6b6b, font-style: italic, opacity: 0.9

How to review

  Prerequisites

  Install the Live Server extension for VS Code (by Ritwick Dey).

  Steps

  - Pull the branch and install dependencies
  git fetch origin
  git checkout 15-add-errorfallback-ui-for-failed-content
  npm install
  - Run checks (should all pass)
  npm run lint
  npm run format:check
  npm test
  - Test config failure — Double-click index.html, open with Live Server, then rename config.json to config.json.bak temporarily. Reload
  the page. The title should show "Configuration could not be loaded" in red italic text. Rename it back when done.
  - Test RSS failure — In config.json, change the RSS URL to something invalid (e.g. "url": "https://example.com/bad-feed"). Reload. The
  News panel should show "Feed unavailable" in red italic.
  - Test image failure — In config.json, change an image URL to something that doesn't exist (e.g. "url": "nonexistent.jpg"). Reload. The
   Gallery panel should show "Image not found" in red italic.
  - Test weather failure — Already handled from before. Should show "--°F" / "Weather unavailable" when the API is unreachable.
  - Test normal operation — Restore config.json to its original state. Reload. Everything should work normally with no red error text
  visible.
  - Check console — Open DevTools (F12 → Console). In all failure scenarios above, errors should still be logged via console.error().

  Test plan

  - npm run lint — zero errors
  - npm run format:check — all files pass
  - npm test — passes
  - Visual review via Live Server (see steps above)