### PR TITLE
Add portrait/landscape orientation toggle (1080x1920 / 1920x1080)  

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,3 +1,30 @@
+// ================= ORIENTATION TOGGLE =================
+
+(function () {
+  var dashboard = document.getElementById('dashboard');
+  var button = document.getElementById('orientation-btn');
+
+  function applyOrientation(mode) {
+    dashboard.classList.remove('landscape', 'portrait');
+    dashboard.classList.add(mode);
+    button.textContent =
+      mode === 'portrait' ? 'Switch to Landscape' : 'Switch to Portrait';
+  }
+
+  // Restore saved orientation
+  var saved = localStorage.getItem('orientation');
+  if (saved) {
+    applyOrientation(saved);
+  }
+
+  button.addEventListener('click', function () {
+    var isLandscape = dashboard.classList.contains('landscape');
+    var next = isLandscape ? 'portrait' : 'landscape';
+    applyOrientation(next);
+    localStorage.setItem('orientation', next);
+  });
+})();
+
 // ================= GENERIC CONTENT CYCLER =================
 
 /**

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
     <link rel="stylesheet" href="style.css" />
   </head>
   <body>
-    <div class="dashboard">
+    <div class="dashboard landscape" id="dashboard">
       <header class="header">
         <h1 id="title">Computer Science Department</h1>
         <label for="cityName">City:</label>
@@ -69,6 +69,9 @@
       </footer>
     </div>
 
+    <button class="orientation-toggle" id="orientation-btn">
+      Switch to Portrait
+    </button>
     <script src="app.js"></script>
   </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -13,6 +13,14 @@ body {
 
 .dashboard {
   display: grid;
+  gap: 16px;
+  height: 100vh;
+  padding: 16px;
+}
+
+/* ================= LANDSCAPE (1920x1080) ================= */
+
+.dashboard.landscape {
   grid-template-areas:
     'header header'
     'clock weather'
@@ -21,9 +29,21 @@ body {
     'footer footer';
   grid-template-columns: 2fr 1fr;
   grid-template-rows: auto 2fr 2fr 2fr auto;
-  gap: 16px;
-  height: 100vh;
-  padding: 16px;
+}
+
+/* ================= PORTRAIT (1080x1920) ================= */
+
+.dashboard.portrait {
+  grid-template-areas:
+    'header'
+    'clock'
+    'weather'
+    'news'
+    'announcements'
+    'images'
+    'footer';
+  grid-template-columns: 1fr;
+  grid-template-rows: auto auto auto 1fr 1fr 1fr auto;
 }
 
 .header {
@@ -151,6 +171,28 @@ h2 {
 #announcements-container {
   font-size: 1.3rem;
   line-height: 1.5;
+}
+
+/* ================= ORIENTATION TOGGLE ================= */
+
+.orientation-toggle {
+  position: fixed;
+  bottom: 16px;
+  right: 16px;
+  background-color: #333;
+  color: white;
+  border: 1px solid #555;
+  border-radius: 8px;
+  padding: 8px 14px;
+  font-size: 0.85rem;
+  cursor: pointer;
+  z-index: 100;
+  opacity: 0.7;
+  transition: opacity 0.3s;
+}
+
+.orientation-toggle:hover {
+  opacity: 1;
 }
 
 /* ================= CYCLING TRANSITIONS ================= */


### PR DESCRIPTION
 Summary                                                                                                                              
                                                                                                                                         
  Closes #7. Adds support for both portrait (1080x1920) and landscape (1920x1080) display orientations with a toggle button to switch    
  between them, as requested by Dr. Paul.                                                                                                

  What changed
  File: style.css
  Change: Split .dashboard grid into .dashboard.landscape (2-column) and .dashboard.portrait (single-column stacked); added
    .orientation-toggle button styling
  ────────────────────────────────────────
  File: index.html
  Change: Added id="dashboard" and default landscape class; added toggle button
  ────────────────────────────────────────
  File: app.js
  Change: Added orientation toggle logic with localStorage persistence
  Layout comparison

  Landscape (1920x1080) — current default, 2-column:
  header      header
  clock       weather
  news        announcements
  images      images
  footer      footer

  Portrait (1080x1920) — single-column stacked:
  header
  clock
  weather
  news
  announcements
  images
  footer

  How to review

  Prerequisites

  Install the Live Server extension for VS Code (by Ritwick Dey).

  Steps

  - Pull the branch and install dependencies
  git fetch origin
  git checkout 7-fix-vertical-portrait-orientation-layout
  npm install
  - Run checks (should all pass)
  npm run lint
  npm run format:check
  npm test
  - Open in Live Server — double-click index.html in VS Code, right-click and select "Open with Live Server"
  - Test landscape mode — the dashboard should load in 2-column layout by default. All panels should be visible and properly sized.
  - Test portrait mode — click the "Switch to Portrait" button in the bottom-right corner. The layout should switch to a single-column
  stack. All panels should be visible without horizontal scrolling.
  - Test toggle back — click "Switch to Landscape". Layout should return to 2-column.
  - Test persistence — switch to portrait, then reload the page (F5). The dashboard should still be in portrait mode. The button should
  say "Switch to Landscape".
  - Test at both resolutions — open DevTools (F12), toggle device toolbar (Ctrl+Shift+M / Cmd+Shift+M), and test at:
    - 1920x1080 in landscape mode
    - 1080x1920 in portrait mode
    - Verify no content is cut off or overflowing in either mode
  - Check the toggle button — it should be a small subtle button in the bottom-right corner, semi-transparent, and more visible on hover.

  Test plan

  - npm run lint — zero errors
  - npm run format:check — all files pass
  - npm test — passes
  - Visual review via Live Server (see steps above)