### PR TITLE
Add unit tests and fix the news feed

### DIFF
--- a/__tests__/clock.test.js
+++ b/__tests__/clock.test.js
@@ -1,0 +1,8 @@
+import { formatTime } from '../clock.js';
+
+test('formats time correctly', () => {
+  const date = new Date('2026-05-02T17:00:00');
+  const result = formatTime(date);
+
+  expect(result).toContain('5:00:00');
+});

--- a/__tests__/config.test.js
+++ b/__tests__/config.test.js
@@ -1,0 +1,16 @@
+import config from '../config.json';
+
+describe('config.json', () => {
+  test('has RSS config', () => {
+    expect(config.rss).toBeDefined();
+    expect(config.rss.url).toContain('bbc');
+  });
+
+  test('has announcements', () => {
+    expect(Array.isArray(config.announcements.items)).toBe(true);
+  });
+
+  test('has images array', () => {
+    expect(Array.isArray(config.images.items)).toBe(true);
+  });
+});

--- a/__tests__/config.test.js
+++ b/__tests__/config.test.js
@@ -1,9 +1,19 @@
 import config from '../config.json';
 
 describe('config.json', () => {
-  test('has RSS config', () => {
+  test('has RSS config with sources', () => {
     expect(config.rss).toBeDefined();
-    expect(config.rss.url).toContain('bbc');
+    expect(Array.isArray(config.rss.sources)).toBe(true);
+    expect(config.rss.sources.length).toBeGreaterThan(0);
+  });
+
+  test('includes BBC News source', () => {
+    const bbc = config.rss.sources.find(
+      (source) => source.name === 'BBC News'
+    );
+
+    expect(bbc).toBeDefined();
+    expect(bbc.url).toContain('bbc');
   });
 
   test('has announcements', () => {

--- a/__tests__/cycler.test.js
+++ b/__tests__/cycler.test.js
@@ -1,0 +1,19 @@
+import { getNextIndex } from '../cycler.js';
+
+describe('getNextIndex', () => {
+  test('increments index normally', () => {
+    expect(getNextIndex(0, 3)).toBe(1);
+  });
+
+  test('wraps around to 0', () => {
+    expect(getNextIndex(2, 3)).toBe(0);
+  });
+
+  test('handles single item', () => {
+    expect(getNextIndex(0, 1)).toBe(0);
+  });
+
+  test('handles empty list', () => {
+    expect(getNextIndex(0, 0)).toBe(0);
+  });
+});

--- a/__tests__/htmlStructure.test.js
+++ b/__tests__/htmlStructure.test.js
@@ -1,0 +1,27 @@
+
+import fs from 'fs';
+
+describe('index.html structure', () => {
+  let html;
+
+  beforeAll(() => {
+    html = fs.readFileSync('index.html', 'utf8');
+    document.documentElement.innerHTML = html;
+  });
+
+  test('has weather elements required by app.js', () => {
+    expect(document.getElementById('weather-location')).not.toBeNull();
+    expect(document.getElementById('weather-temp')).not.toBeNull();
+    expect(document.getElementById('weather-condition')).not.toBeNull();
+  });
+
+  test('has news elements required by app.js', () => {
+    expect(document.getElementById('news-container')).not.toBeNull();
+    expect(document.getElementById('news-source')).not.toBeNull();
+  });
+
+  test('has clock and date elements required by app.js', () => {
+    expect(document.querySelector('.clock')).not.toBeNull();
+    expect(document.querySelector('.date')).not.toBeNull();
+  });
+});

--- a/__tests__/news.test.js
+++ b/__tests__/news.test.js
@@ -1,0 +1,42 @@
+import { parseNewsItems } from '../news.js';
+
+describe('parseNewsItems', () => {
+  test('parses RSS titles', () => {
+    const xml = `
+      <rss><channel>
+        <item><title>Headline 1</title></item>
+        <item><title>Headline 2</title></item>
+      </channel></rss>
+    `;
+
+    expect(parseNewsItems(xml, 5)).toEqual(['Headline 1', 'Headline 2']);
+  });
+
+  test('limits number of headlines', () => {
+    const xml = `
+      <rss><channel>
+        <item><title>One</title></item>
+        <item><title>Two</title></item>
+        <item><title>Three</title></item>
+      </channel></rss>
+    `;
+
+    expect(parseNewsItems(xml, 2)).toEqual(['One', 'Two']);
+  });
+
+  test('uses fallback title when missing', () => {
+    const xml = `<rss><channel><item></item></channel></rss>`;
+
+    expect(parseNewsItems(xml, 5)).toEqual(['No title']);
+  });
+
+  test('returns empty array when there are no items', () => {
+    const xml = `<rss><channel></channel></rss>`;
+
+    expect(parseNewsItems(xml, 5)).toEqual([]);
+  });
+});
+
+test('throws error for invalid input', () => {
+  expect(() => parseNewsItems(null)).toThrow();
+});

--- a/__tests__/smoke.test.js
+++ b/__tests__/smoke.test.js
@@ -1,0 +1,3 @@
+test('Jest is working', () => {
+  expect(1 + 1).toBe(2);
+});

--- a/__tests__/weather.test.js
+++ b/__tests__/weather.test.js
@@ -1,0 +1,19 @@
+import { getWeatherDescription } from '../weather.js';
+
+describe('getWeatherDescription', () => {
+  test('returns clear sky for code 0', () => {
+    expect(getWeatherDescription(0)).toBe('Clear sky');
+  });
+
+  test('returns heavy rain for code 65', () => {
+    expect(getWeatherDescription(65)).toBe('Heavy rain');
+  });
+
+  test('returns thunderstorm with heavy hail for code 99', () => {
+    expect(getWeatherDescription(99)).toBe('Thunderstorm with heavy hail');
+  });
+
+  test('returns unknown weather for unmapped code', () => {
+    expect(getWeatherDescription(999)).toBe('Unknown weather');
+  });
+});

--- a/__tests__/weatherDisplay.test.js
+++ b/__tests__/weatherDisplay.test.js
@@ -1,0 +1,24 @@
+
+import { updateWeatherDisplay } from '../weatherDisplay.js';
+
+describe('updateWeatherDisplay', () => {
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <div id="weather-location"></div>
+      <div id="weather-temp"></div>
+      <div id="weather-condition"></div>
+    `;
+  });
+
+  test('updates the weather display text', () => {
+    updateWeatherDisplay('Denver, CO', '72°F', 'Clear sky');
+
+    expect(document.getElementById('weather-location').textContent).toBe(
+      'Denver, CO'
+    );
+    expect(document.getElementById('weather-temp').textContent).toBe('72°F');
+    expect(document.getElementById('weather-condition').textContent).toBe(
+      'Clear sky'
+    );
+  });
+});

--- a/app.js
+++ b/app.js
@@ -142,10 +142,10 @@ async function loadConfig() {
         sourceEl.textContent = config.rss.source;
       }
       fetchNews(
-        config.rss.url,
-        config.rss.maxItems || 5,
-        config.rss.cycle || 6
-      );
+  config.rss.sources || [{ name: config.rss.source, url: config.rss.url }],
+  config.rss.maxItems || 5,
+  config.rss.cycle || 6
+);
     }
 
     // Start announcements cycling
@@ -414,53 +414,86 @@ async function fetchWeather() {
 
 // ================= RSS NEWS =================
 
-function fetchNews(rssUrl, maxItems, cycleSec) {
-  const proxyUrl = `https://api.allorigins.win/raw?url=${encodeURIComponent(rssUrl)}`;
+function fetchWithTimeout(url, timeoutMs = 5000) {
+  const controller = new AbortController();
 
-  fetch(proxyUrl)
-    .then(function (response) {
-      if (!response.ok) {
-        throw new Error("Failed to fetch RSS feed");
+  const timeoutId = setTimeout(function () {
+    controller.abort();
+  }, timeoutMs);
+
+  return fetch(url, { signal: controller.signal }).finally(function () {
+    clearTimeout(timeoutId);
+  });
+}
+
+
+async function fetchNews(rssSources, maxItems, cycleSec) {
+  const sources = Array.isArray(rssSources) ? rssSources : [rssSources];
+
+  try {
+    let headlines = [];
+
+    for (const source of sources) {
+      try {
+        console.log('Trying RSS source:', source.name);
+
+        const proxyUrl = `https://api.allorigins.win/raw?url=${encodeURIComponent(source.url)}`;
+        const response = await fetchWithTimeout(proxyUrl, 5000);
+
+        if (!response.ok) {
+          throw new Error('Failed to fetch RSS feed');
+        }
+
+        const xmlText = await response.text();
+        const parser = new DOMParser();
+        const xmlDoc = parser.parseFromString(xmlText, 'text/xml');
+
+        const parseError = xmlDoc.querySelector('parsererror');
+        if (parseError) {
+          throw new Error('Invalid RSS XML');
+        }
+
+        const items = xmlDoc.querySelectorAll('item');
+
+        headlines = Array.from(items)
+          .slice(0, maxItems)
+          .map(function (item) {
+            return item.querySelector('title')?.textContent || 'No title';
+          });
+
+        if (headlines.length > 0) {
+          const sourceEl = document.getElementById('news-source');
+
+          if (sourceEl && source.name) {
+            sourceEl.textContent = source.name;
+          }
+
+          break;
+        }
+      } catch (error) {
+        console.warn('RSS source failed:', source.name, error);
       }
-      return response.text();
-    })
-    .then(function (xmlText) {
-      const parser = new DOMParser();
-      const xmlDoc = parser.parseFromString(xmlText, "text/xml");
+    }
 
-      const parseError = xmlDoc.querySelector("parsererror");
-      if (parseError) {
-        throw new Error("Invalid RSS XML");
-      }
+    if (headlines.length === 0) {
+      throw new Error('No news items found');
+    }
 
-      const items = xmlDoc.querySelectorAll("item");
-
-      const headlines = Array.from(items)
-        .slice(0, maxItems)
-        .map(function (item) {
-          return item.querySelector("title")?.textContent || "No title";
-        });
-
-      if (headlines.length > 0) {
-        startCycler(
-          "news-container",
-          headlines,
-          function (text) {
-            const p = document.createElement("p");
-            p.textContent = "\u2022 " + text;
-            return p;
-          },
-          cycleSec
-        );
-      } else {
-        throw new Error("No news items found");
-      }
-    })
-    .catch(function (error) {
-      console.error("News error:", error);
-      document.getElementById("news-container").innerHTML =
-        '<p class="error-message">Feed unavailable</p>';
-    });
+    startCycler(
+      'news-container',
+      headlines,
+      function (text) {
+        const p = document.createElement('p');
+        p.textContent = '\u2022 ' + text;
+        return p;
+      },
+      cycleSec
+    );
+  } catch (error) {
+    console.error('News error:', error);
+    document.getElementById('news-container').innerHTML =
+      '<p class="error-message">Feed unavailable</p>';
+  }
 }
 
 // ================= RUN APP =================

--- a/app.js
+++ b/app.js
@@ -415,42 +415,50 @@ async function fetchWeather() {
 // ================= RSS NEWS =================
 
 function fetchNews(rssUrl, maxItems, cycleSec) {
-  const proxyUrl = `https://api.allorigins.win/get?url=${encodeURIComponent(rssUrl)}`;
+  const proxyUrl = `https://api.allorigins.win/raw?url=${encodeURIComponent(rssUrl)}`;
 
   fetch(proxyUrl)
     .then(function (response) {
       if (!response.ok) {
-        throw new Error('Failed to fetch RSS feed');
+        throw new Error("Failed to fetch RSS feed");
       }
-      return response.json();
+      return response.text();
     })
-    .then(function (data) {
+    .then(function (xmlText) {
       const parser = new DOMParser();
-      const xmlDoc = parser.parseFromString(data.contents, 'text/xml');
-      const items = xmlDoc.querySelectorAll('item');
+      const xmlDoc = parser.parseFromString(xmlText, "text/xml");
+
+      const parseError = xmlDoc.querySelector("parsererror");
+      if (parseError) {
+        throw new Error("Invalid RSS XML");
+      }
+
+      const items = xmlDoc.querySelectorAll("item");
 
       const headlines = Array.from(items)
         .slice(0, maxItems)
         .map(function (item) {
-          return item.querySelector('title')?.textContent || 'No title';
+          return item.querySelector("title")?.textContent || "No title";
         });
 
       if (headlines.length > 0) {
         startCycler(
-          'news-container',
+          "news-container",
           headlines,
           function (text) {
-            const p = document.createElement('p');
-            p.textContent = '\u2022 ' + text;
+            const p = document.createElement("p");
+            p.textContent = "\u2022 " + text;
             return p;
           },
           cycleSec
         );
+      } else {
+        throw new Error("No news items found");
       }
     })
     .catch(function (error) {
-      console.error('News error:', error);
-      document.getElementById('news-container').innerHTML =
+      console.error("News error:", error);
+      document.getElementById("news-container").innerHTML =
         '<p class="error-message">Feed unavailable</p>';
     });
 }
@@ -481,7 +489,3 @@ if (document.getElementById('Geolocation').checked) {
 }
 
 loadConfig();
-
-fetchNews();
-setInterval(fetchNews, 15 * 60 * 1000); // Refresh news every 15 minutes
-//setInterval(rotateHeadline, 5000); // Rotate headline every 5 seconds

--- a/clock.js
+++ b/clock.js
@@ -1,0 +1,8 @@
+export function formatTime(date) {
+  return date.toLocaleTimeString([], {
+    hour: 'numeric',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: true,
+  });
+}

--- a/config.json
+++ b/config.json
@@ -10,13 +10,25 @@
     "location": "Denver, CO",
     "units": "fahrenheit"
   },
-  "rss": {
-    "enabled": true,
-    "url": "https://feeds.bbci.co.uk/news/rss.xml",
-    "source": "BBC News",
-    "maxItems": 5,
-    "cycle": 6
-  },
+"rss": {
+  "enabled": true,
+  "sources": [
+    {
+      "name": "BBC News",
+      "url": "https://feeds.bbci.co.uk/news/rss.xml"
+    },
+    {
+      "name": "New York Times News",
+      "url": "https://rss.nytimes.com/services/xml/rss/nyt/HomePage.xml"
+    },
+    {
+      "name": "NPR News",
+      "url": "https://feeds.npr.org/1001/rss.xml"
+    }
+  ],
+  "maxItems": 5,
+  "cycle": 6
+},
   "announcements": {
     "items": [
       "Welcome to the Computer Science Department.",

--- a/cycler.js
+++ b/cycler.js
@@ -1,0 +1,4 @@
+export function getNextIndex(current, length) {
+  if (length === 0) return 0;
+  return (current + 1) % length;
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,3 +1,4 @@
 export default {
   transform: {},
+  testEnvironment: 'jsdom',
 };

--- a/news.js
+++ b/news.js
@@ -1,0 +1,17 @@
+export function parseNewsItems(xmlText, maxItems = 5) {
+  if (!xmlText || typeof xmlText !== 'string') {
+    throw new Error('Invalid RSS XML');
+  }
+
+  const parser = new DOMParser();
+  const xmlDoc = parser.parseFromString(xmlText, 'text/xml');
+
+  const parseError = xmlDoc.querySelector('parsererror');
+  if (parseError) {
+    throw new Error('Invalid RSS XML');
+  }
+
+  return Array.from(xmlDoc.querySelectorAll('item'))
+    .slice(0, maxItems)
+    .map((item) => item.querySelector('title')?.textContent || 'No title');
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,9 +15,31 @@
         "globals": "^17.3.0",
         "husky": "^9.1.7",
         "jest": "^30.0.0",
+        "jest-environment-jsdom": "^30.3.0",
         "lint-staged": "^16.2.7",
         "prettier": "^3.8.1"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -50,6 +72,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -514,6 +537,123 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@emnapi/core": {
       "version": "1.9.2",
@@ -984,6 +1124,34 @@
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
+    "node_modules/@jest/environment-jsdom-abstract": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/environment-jsdom-abstract/-/environment-jsdom-abstract-30.3.0.tgz",
+      "integrity": "sha512-0hNFs5N6We3DMCwobzI0ydhkY10sT1tZSC0AAiy+0g2Dt/qEWgrcV5BrMxPczhe41cxW4qm6X+jqZaUdpZIajA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "30.3.0",
+        "@jest/fake-timers": "30.3.0",
+        "@jest/types": "30.3.0",
+        "@types/jsdom": "^21.1.7",
+        "@types/node": "*",
+        "jest-mock": "30.3.0",
+        "jest-util": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@jest/expect": {
       "version": "30.3.0",
       "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-30.3.0.tgz",
@@ -1437,6 +1605,18 @@
         "@types/istanbul-lib-report": "*"
       }
     },
+    "node_modules/@types/jsdom": {
+      "version": "21.1.7",
+      "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-21.1.7.tgz",
+      "integrity": "sha512-yOriVnggzrnQ3a9OKOCxaVuSug3w3/SbOj5i7VwXWZEyUNl3bLF9V3MfxGbZKuwqJOQyRfqXyROBB1CoZLFWzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/tough-cookie": "*",
+        "parse5": "^7.0.0"
+      }
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -1458,6 +1638,13 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/tough-cookie": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
+      "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
       "dev": true,
       "license": "MIT"
     },
@@ -1760,6 +1947,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1775,6 +1963,16 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/ajv": {
@@ -2023,6 +2221,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -2367,6 +2566,34 @@
         "node": ">= 8"
       }
     },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -2384,6 +2611,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/dedent": {
       "version": "1.7.2",
@@ -2461,6 +2695,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/environment": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
@@ -2513,6 +2760,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3025,12 +3273,53 @@
         "node": ">=8"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
     },
     "node_modules/human-signals": {
       "version": "2.1.0",
@@ -3056,6 +3345,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/typicode"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/ignore": {
@@ -3189,6 +3491,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/is-stream": {
       "version": "2.0.1",
@@ -3512,6 +3821,29 @@
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-environment-jsdom": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-30.3.0.tgz",
+      "integrity": "sha512-RLEOJy6ip1lpw0yqJ8tB3i88FC7VBz7i00Zvl2qF71IdxjS98gC9/0SPWYIBVXHm5hgCYK0PAlSlnHGGy9RoMg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "30.3.0",
+        "@jest/environment-jsdom-abstract": "30.3.0",
+        "jsdom": "^26.1.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
       }
     },
     "node_modules/jest-environment-node": {
@@ -3920,6 +4252,47 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
+      "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "cssstyle": "^4.2.1",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.5.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.16",
+        "parse5": "^7.2.1",
+        "rrweb-cssom": "^0.8.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^5.1.1",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.1.1",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
       }
     },
     "node_modules/jsesc": {
@@ -4416,6 +4789,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/nwsapi": {
+      "version": "2.2.23",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.23.tgz",
+      "integrity": "sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -4539,6 +4919,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/path-exists": {
@@ -4864,6 +5257,33 @@
       "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
     },
     "node_modules/semver": {
       "version": "6.3.1",
@@ -5209,6 +5629,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/synckit": {
       "version": "0.11.12",
       "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.12.tgz",
@@ -5272,12 +5699,58 @@
         "node": ">=18"
       }
     },
+    "node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tmpl": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
       "integrity": "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==",
       "dev": true,
       "license": "BSD-3-Clause"
+    },
+    "node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/tslib": {
       "version": "2.8.1",
@@ -5421,6 +5894,19 @@
         "node": ">=10.12.0"
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/walker": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
@@ -5429,6 +5915,54 @@
       "license": "Apache-2.0",
       "dependencies": {
         "makeerror": "1.0.12"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/which": {
@@ -5582,6 +6116,45 @@
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
+    },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "globals": "^17.3.0",
     "husky": "^9.1.7",
     "jest": "^30.0.0",
+    "jest-environment-jsdom": "^30.3.0",
     "lint-staged": "^16.2.7",
     "prettier": "^3.8.1"
   },

--- a/weather.js
+++ b/weather.js
@@ -1,0 +1,30 @@
+export function getWeatherDescription(code) {
+  const weatherCodes = {
+    0: 'Clear sky',
+    1: 'Mainly clear',
+    2: 'Partly cloudy',
+    3: 'Overcast',
+    45: 'Fog',
+    48: 'Depositing rime fog',
+    51: 'Light drizzle',
+    53: 'Moderate drizzle',
+    55: 'Dense drizzle',
+    61: 'Slight rain',
+    63: 'Moderate rain',
+    65: 'Heavy rain',
+    71: 'Slight snow',
+    73: 'Moderate snow',
+    75: 'Heavy snow',
+    77: 'Snow grains',
+    80: 'Slight rain showers',
+    81: 'Moderate rain showers',
+    82: 'Violent rain showers',
+    85: 'Slight snow showers',
+    86: 'Heavy snow showers',
+    95: 'Thunderstorm',
+    96: 'Thunderstorm with slight hail',
+    99: 'Thunderstorm with heavy hail',
+  };
+
+  return weatherCodes[code] || 'Unknown weather';
+}

--- a/weatherDisplay.js
+++ b/weatherDisplay.js
@@ -1,0 +1,10 @@
+
+export function updateWeatherDisplay(location, temp, condition) {
+  const locationElement = document.getElementById('weather-location');
+  const tempElement = document.getElementById('weather-temp');
+  const conditionElement = document.getElementById('weather-condition');
+
+  locationElement.textContent = location;
+  tempElement.textContent = temp;
+  conditionElement.textContent = condition;
+}


### PR DESCRIPTION
This PR adds unit tests across the project to improve reliability and code quality. Tests were created for core logic, configuration validation, DOM updates, and helper functions while keeping the main application (app.js) unchanged.
Note that app.js was changed to fix the news feed, but it was untouched when implementing the unit tests. The news feed now has two backup options to hopefully prevent it from ever being unavailable.

**What was added**
News parsing tests
parseNewsItems extracted and tested for RSS parsing behavior
Cycler logic tests
Core index cycling logic tested independently
Weather tests
getWeatherDescription tested for multiple weather codes and fallback behavior
Weather display tests
DOM updates verified for location, temperature, and condition
Config tests
Validates required fields and structure in config.json
HTML structure tests
Ensures required DOM elements exist for app functionality
Smoke test
Confirms Jest setup is working

Test Coverage
Overall coverage: ~95%
All helper modules (cycler, weather, display) at 100%
Remaining uncovered lines are defensive/error-handling branches

**How to test**
1. Install dependencies
npm install
2. Run tests
npm test -- --coverage
Total should be over 90% (only one missing line)
3. Open Live Server
Confirm News feed is loading (either BBC, NYT, or NPR News)