### PR TITLE
Feature/news qr thumbnails

### DIFF
--- a/__tests__/news.test.js
+++ b/__tests__/news.test.js
@@ -1,33 +1,89 @@
 import { parseNewsItems } from '../news.js';
 
 describe('parseNewsItems', () => {
-  test('parses RSS titles', () => {
+  test('parses RSS titles, links, and thumbnails', () => {
+    const xml = `
+  <rss xmlns:media="http://search.yahoo.com/mrss/"><channel>
+    <item>
+      <title>Headline 1</title>
+      <link>https://example.com/story-1</link>
+      <media:thumbnail url="https://example.com/image-1.jpg" />
+    </item>
+    <item>
+      <title>Headline 2</title>
+      <link>https://example.com/story-2</link>
+      <media:thumbnail url="https://example.com/image-2.jpg" />
+    </item>
+  </channel></rss>
+`;
+
+    expect(parseNewsItems(xml, 5)).toEqual([
+      {
+        title: 'Headline 1',
+        link: 'https://example.com/story-1',
+        thumbnail: 'https://example.com/image-1.jpg',
+      },
+      {
+        title: 'Headline 2',
+        link: 'https://example.com/story-2',
+        thumbnail: 'https://example.com/image-2.jpg',
+      },
+    ]);
+  });
+
+  test('limits number of news items', () => {
     const xml = `
       <rss><channel>
-        <item><title>Headline 1</title></item>
-        <item><title>Headline 2</title></item>
+        <item><title>One</title><link>https://example.com/one</link></item>
+        <item><title>Two</title><link>https://example.com/two</link></item>
+        <item><title>Three</title><link>https://example.com/three</link></item>
       </channel></rss>
     `;
 
-    expect(parseNewsItems(xml, 5)).toEqual(['Headline 1', 'Headline 2']);
+    expect(parseNewsItems(xml, 2)).toEqual([
+      {
+        title: 'One',
+        link: 'https://example.com/one',
+        thumbnail: null,
+      },
+      {
+        title: 'Two',
+        link: 'https://example.com/two',
+        thumbnail: null,
+      },
+    ]);
   });
 
-  test('limits number of headlines', () => {
-    const xml = `
-      <rss><channel>
-        <item><title>One</title></item>
-        <item><title>Two</title></item>
-        <item><title>Three</title></item>
-      </channel></rss>
-    `;
-
-    expect(parseNewsItems(xml, 2)).toEqual(['One', 'Two']);
-  });
-
-  test('uses fallback title when missing', () => {
+  test('uses fallback values when title, link, or thumbnail are missing', () => {
     const xml = `<rss><channel><item></item></channel></rss>`;
 
-    expect(parseNewsItems(xml, 5)).toEqual(['No title']);
+    expect(parseNewsItems(xml, 5)).toEqual([
+      {
+        title: 'No title',
+        link: null,
+        thumbnail: null,
+      },
+    ]);
+  });
+
+  test('uses media content as backup thumbnail', () => {
+    const xml = `
+  <rss xmlns:media="http://search.yahoo.com/mrss/"><channel>
+    <item>
+      <title>Backup image</title>
+      <link>https://example.com/backup</link>
+      <media:content url="https://example.com/content-image.jpg" />
+    </item>
+  </channel></rss>
+`;
+
+    expect(parseNewsItems(xml, 5)).toEqual([
+      {
+        title: 'Backup image',
+        link: 'https://example.com/backup',
+        thumbnail: 'https://example.com/content-image.jpg',
+      },
+    ]);
   });
 
   test('returns empty array when there are no items', () => {
@@ -35,8 +91,8 @@ describe('parseNewsItems', () => {
 
     expect(parseNewsItems(xml, 5)).toEqual([]);
   });
-});
 
-test('throws error for invalid input', () => {
-  expect(() => parseNewsItems(null)).toThrow();
+  test('throws error for invalid input', () => {
+    expect(() => parseNewsItems(null)).toThrow();
+  });
 });

--- a/app.js
+++ b/app.js
@@ -431,7 +431,7 @@ async function fetchNews(rssSources, maxItems, cycleSec) {
   const sources = Array.isArray(rssSources) ? rssSources : [rssSources];
 
   try {
-    let headlines = [];
+    let newsItems = [];
 
     for (const source of sources) {
       try {
@@ -455,13 +455,26 @@ async function fetchNews(rssSources, maxItems, cycleSec) {
 
         const items = xmlDoc.querySelectorAll('item');
 
-        headlines = Array.from(items)
+        newsItems = Array.from(items)
           .slice(0, maxItems)
           .map(function (item) {
-            return item.querySelector('title')?.textContent || 'No title';
+            const thumbnail =
+              item
+                .querySelector('media\\:thumbnail, thumbnail')
+                ?.getAttribute('url') ||
+              item
+                .querySelector('media\\:content, content')
+                ?.getAttribute('url') ||
+              null;
+
+            return {
+              title: item.querySelector('title')?.textContent || 'No title',
+              link: item.querySelector('link')?.textContent || null,
+              thumbnail: thumbnail,
+            };
           });
 
-        if (headlines.length > 0) {
+        if (newsItems.length > 0) {
           const sourceEl = document.getElementById('news-source');
 
           if (sourceEl && source.name) {
@@ -475,17 +488,51 @@ async function fetchNews(rssSources, maxItems, cycleSec) {
       }
     }
 
-    if (headlines.length === 0) {
+    if (newsItems.length === 0) {
       throw new Error('No news items found');
     }
 
     startCycler(
       'news-container',
-      headlines,
-      function (text) {
-        const p = document.createElement('p');
-        p.textContent = '\u2022 ' + text;
-        return p;
+      newsItems,
+      function (item) {
+        const wrapper = document.createElement('div');
+        wrapper.className = 'news-item';
+
+        if (item.thumbnail) {
+          const img = document.createElement('img');
+          img.className = 'news-thumbnail';
+          img.src = item.thumbnail;
+          img.alt = item.title;
+
+          img.onerror = function () {
+            img.style.display = 'none';
+          };
+
+          wrapper.appendChild(img);
+        }
+
+        const headline = document.createElement('p');
+        headline.className = 'news-headline';
+        headline.textContent = '\u2022 ' + item.title;
+        wrapper.appendChild(headline);
+
+        if (item.link) {
+          const qr = document.createElement('img');
+          qr.className = 'news-qr';
+          qr.alt = 'QR code for article';
+          qr.src =
+            'https://api.qrserver.com/v1/create-qr-code/?size=120x120&data=' +
+            encodeURIComponent(item.link);
+
+          qr.onerror = function () {
+            qr.style.display = 'none';
+          };
+
+          wrapper.appendChild(qr);
+        }
+
+        return wrapper;
       },
       cycleSec
     );

--- a/app.js
+++ b/app.js
@@ -461,7 +461,7 @@ async function fetchNews(rssSources, maxItems, cycleSec) {
             break;
             }
           } catch (err) {
-            console.warn('Proxy failed:', proxyUrl);
+            console.warn('Proxy failed:', proxyUrl, err);
           }
         }
 

--- a/app.js
+++ b/app.js
@@ -437,14 +437,38 @@ async function fetchNews(rssSources, maxItems, cycleSec) {
       try {
         console.log('Trying RSS source:', source.name);
 
-        const proxyUrl = `https://api.allorigins.win/raw?url=${encodeURIComponent(source.url)}`;
-        const response = await fetchWithTimeout(proxyUrl, 5000);
+        const proxyUrls = [
+        `https://api.allorigins.win/raw?url=${encodeURIComponent(source.url)}`,
+        `https://api.codetabs.com/v1/proxy?quest=${encodeURIComponent(source.url)}`
+        ];
+        
+        let xmlText = null;
 
-        if (!response.ok) {
-          throw new Error('Failed to fetch RSS feed');
+      for (const proxyUrl of proxyUrls) {
+        try {
+            console.log('Trying proxy:', proxyUrl);
+
+            const response = await fetchWithTimeout(proxyUrl, 5000);
+
+            if (!response.ok) {
+              throw new Error('Bad response');
+            }
+
+            xmlText = await response.text();
+
+            if (xmlText && xmlText.length > 0) {
+              console.log('Proxy success');
+            break;
+            }
+          } catch (err) {
+            console.warn('Proxy failed:', proxyUrl);
+          }
         }
 
-        const xmlText = await response.text();
+      if (!xmlText) {
+        throw new Error('All proxies failed');
+      }
+
         const parser = new DOMParser();
         const xmlDoc = parser.parseFromString(xmlText, 'text/xml');
 
@@ -497,7 +521,7 @@ async function fetchNews(rssSources, maxItems, cycleSec) {
       newsItems,
       function (item) {
         const wrapper = document.createElement('div');
-        wrapper.className = 'news-item';
+        wrapper.className = item.thumbnail ? 'news-item' : 'news-item no-thumbnail';
 
         if (item.thumbnail) {
           const img = document.createElement('img');

--- a/news.js
+++ b/news.js
@@ -11,7 +11,20 @@ export function parseNewsItems(xmlText, maxItems = 5) {
     throw new Error('Invalid RSS XML');
   }
 
-  return Array.from(xmlDoc.querySelectorAll('item'))
+  const items = xmlDoc.querySelectorAll('item');
+
+  return Array.from(items)
     .slice(0, maxItems)
-    .map((item) => item.querySelector('title')?.textContent || 'No title');
+    .map(function (item) {
+      const thumbnail =
+        item.querySelector('media\\:thumbnail, thumbnail')?.getAttribute('url') ||
+        item.querySelector('media\\:content, content')?.getAttribute('url') ||
+        null;
+
+      return {
+        title: item.querySelector('title')?.textContent || 'No title',
+        link: item.querySelector('link')?.textContent || null,
+        thumbnail: thumbnail,
+      };
+    });
 }

--- a/style.css
+++ b/style.css
@@ -214,6 +214,53 @@ h2 {
   opacity: 0;
 }
 
+/* ================= NEWS ITEMS ================= */
+
+.news-item {
+  display: grid;
+  grid-template-columns: 120px 1fr 100px;
+  align-items: center;
+  gap: 16px;
+  width: 100%;
+}
+
+.news-thumbnail {
+  width: 120px;
+  height: 80px;
+  object-fit: cover;
+  border-radius: 8px;
+  background-color: #222;
+}
+
+.news-headline {
+  font-size: 1.25rem;
+  line-height: 1.4;
+}
+
+.news-qr {
+  width: 90px;
+  height: 90px;
+  background-color: white;
+  padding: 4px;
+  border-radius: 6px;
+}
+
+/* Stack news content better in portrait mode */
+.dashboard.portrait .news-item {
+  grid-template-columns: 100px 1fr 80px;
+  gap: 12px;
+}
+
+.dashboard.portrait .news-thumbnail {
+  width: 100px;
+  height: 70px;
+}
+
+.dashboard.portrait .news-qr {
+  width: 75px;
+  height: 75px;
+}
+
 /* ================= IMAGE CYCLING ================= */
 
 .images-panel img {

--- a/style.css
+++ b/style.css
@@ -245,6 +245,15 @@ h2 {
   border-radius: 6px;
 }
 
+/* When NO thumbnail exists (fix NPR squish) */
+.news-item.no-thumbnail {
+  grid-template-columns: 1fr 100px;
+}
+
+.news-item.no-thumbnail .news-headline {
+  max-width: 100%;
+}
+
 /* Stack news content better in portrait mode */
 .dashboard.portrait .news-item {
   grid-template-columns: 100px 1fr 80px;


### PR DESCRIPTION
Summary

This PR enhances the news panel by adding QR codes and thumbnail images to each news item. It also updates RSS parsing logic and unit tests to support the richer data structure.

**What was added**
News Feature Enhancements
Updated RSS parsing to include:
article title
article link (used for QR codes)
article thumbnail (when available)
Each news item now displays:
headline text
thumbnail image (if provided by the feed)
QR code linking to the full article
Backup proxy so that the News should not fail anymore

Rendering Improvements
Updated fetchNews to pass structured objects instead of plain strings
Modified news rendering logic to support images and QR codes

Added graceful fallbacks:
hides thumbnail if unavailable
hides QR code if link is missing or fails

Testing Updates
Updated news.js to reflect new parsing structure
Updated news.test.js to validate:
title extraction
link extraction
thumbnail extraction
fallback behavior
Fixed XML namespace issue in tests (xmlns:media) to ensure valid parsing

**Test Coverage**
All modules fully covered, including updated news parsing logic


**How to test**
1. Run the live server
2. Verify news panel
Headlines display correctly
Thumbnail image appears (if available)
QR code appears for each item
3. QR Code Validation
Scan QR code with a phone
Confirm it opens the correct article
4. Edge cases
Items without thumbnails still display correctly
Items without links do not show QR codes
5. Run tests
npm test -- --coverage

**Notes**
RSS feeds vary in structure, so thumbnails may not appear for all sources (e.g., BBC)
QR codes are generated using a public API and hidden if they fail to load
Parsing logic in news.js mirrors app.js to maintain test consistency