### PR TITLE
Raspberry Pi Kiosk Mode & Geolocation Fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,83 @@
 # Sinister-Six-Digital-Signage
 
 This is our awesome group 6 repository for our CS 3250 assignment! We can update the name and description once we settle in.
+
+## Raspberry Pi Setup
+
+### Prerequisites
+
+- Raspberry Pi with Raspberry Pi OS (Desktop)
+- Chromium browser (pre-installed on Raspberry Pi OS)
+- Python 3 (pre-installed on Raspberry Pi OS)
+
+### Installation
+
+1. Clone the repository onto the Pi:
+
+   ```bash
+   git clone https://github.com/CS-3250-SinisterSix/Sinister-Six-Digital-Signage.git
+   cd Sinister-Six-Digital-Signage
+   ```
+
+2. Make the launcher script executable:
+
+   ```bash
+   chmod +x start-signage.sh
+   ```
+
+3. Test it manually:
+
+   ```bash
+   ./start-signage.sh
+   ```
+
+   Press `Alt+F4` (or `Ctrl+C` in the terminal) to exit kiosk mode.
+
+### Autostart on Boot (Desktop Entry)
+
+Copy the provided desktop entry to the autostart directory:
+
+```bash
+mkdir -p ~/.config/autostart
+cp signage.desktop ~/.config/autostart/
+```
+
+Edit `~/.config/autostart/signage.desktop` if the repo is cloned to a path other than `/home/pi/Sinister-Six-Digital-Signage`.
+
+The signage app will now launch automatically when the Pi boots into desktop.
+
+### Disable Screen Blanking
+
+To prevent the screen from going to sleep:
+
+```bash
+sudo raspi-config
+```
+
+Navigate to **Display Options** > **Screen Blanking** > **No**.
+
+Alternatively, add to `/etc/xdg/lxsession/LXDE-pi/autostart`:
+
+```
+@xset s off
+@xset -dpms
+@xset s noblank
+```
+
+### Weather Configuration
+
+The weather location is set in `config.json`:
+
+```json
+{
+  "weather": {
+    "enabled": true,
+    "location": "Denver, CO",
+    "units": "fahrenheit"
+  }
+}
+```
+
+Since the Raspberry Pi has no GPS hardware and browser geolocation is unavailable, the app uses this configured location as a fallback. The geolocation checkbox is unchecked by default.
+
+Users can still type a city name into the weather input field to override the configured location.

--- a/__tests__/config.test.js
+++ b/__tests__/config.test.js
@@ -20,6 +20,12 @@ describe('config.json', () => {
     expect(Array.isArray(config.announcements.items)).toBe(true);
   });
 
+  test('has weather location configured', () => {
+    expect(config.weather).toBeDefined();
+    expect(typeof config.weather.location).toBe('string');
+    expect(config.weather.location.length).toBeGreaterThan(0);
+  });
+
   test('has comics config', () => {
     expect(config.comics).toBeDefined();
     expect(Array.isArray(config.comics.feeds)).toBe(true);

--- a/app.js
+++ b/app.js
@@ -32,7 +32,6 @@
   const themeLabels = {
     dark: 'Dark',
     light: 'Light',
-  
   };
   const body = document.body;
   const button = document.getElementById('theme-btn');
@@ -111,6 +110,10 @@ async function loadConfig() {
     }
 
     const config = await response.json();
+
+    if (config.weather && config.weather.location) {
+      configWeatherLocation = config.weather.location;
+    }
 
     // Apply theme from config (only if no user preference saved)
     if (config.theme && !localStorage.getItem('theme')) {
@@ -315,6 +318,8 @@ function getWeatherDescription(code) {
   return weatherCodes[code] || 'Unknown weather';
 }
 
+var configWeatherLocation = null;
+
 // ================= WEATHER FETCH =================
 
 async function handleSubmit() {
@@ -416,7 +421,14 @@ async function fetchWeather() {
         ? `${location.city}, ${location.principalSubdivision}, ${location.countryCode}`
         : `${location.city}, ${location.countryCode}`;
     } else {
-      WEATHER_LOCATION = JSON.parse(localStorage.getItem('weatherCity')).city;
+      const stored = localStorage.getItem('weatherCity');
+      if (stored) {
+        WEATHER_LOCATION = JSON.parse(stored).city;
+      } else if (configWeatherLocation) {
+        WEATHER_LOCATION = configWeatherLocation;
+      } else {
+        throw new Error('No weather location configured');
+      }
       coords = await getCoordinates(WEATHER_LOCATION);
 
       locationDisplay = coords.admin1
@@ -892,23 +904,16 @@ async function fetchComics(feeds, maxItems, cycleSec) {
 updateClock();
 setInterval(updateClock, 1000);
 
-fetchWeather();
-setTimeout(fetchWeather, 5000);
-setInterval(fetchWeather, 5 * 60 * 1000);
-
-if (!document.getElementById('Geolocation').checked) {
-  document.getElementById('submitBtn').addEventListener('click', handleSubmit);
-}
-
 async function handleUpdate() {
   fetchWeather();
   setTimeout(fetchWeather, 5000);
 }
 
-if (document.getElementById('Geolocation').checked) {
-  document
-    .getElementById('Geolocation')
-    .addEventListener('change', handleUpdate);
-}
+document.getElementById('submitBtn').addEventListener('click', handleSubmit);
+document.getElementById('Geolocation').addEventListener('change', handleUpdate);
 
-loadConfig();
+loadConfig().then(() => {
+  fetchWeather();
+  setTimeout(fetchWeather, 5000);
+  setInterval(fetchWeather, 5 * 60 * 1000);
+});

--- a/index.html
+++ b/index.html
@@ -58,7 +58,6 @@
           class="Geolocation"
           id="Geolocation"
           name="Geolocation"
-          checked
           onchange="handleUpdate()"
         />
         <label for="Geolocation">Use Geolocation</label>

--- a/signage.desktop
+++ b/signage.desktop
@@ -1,0 +1,7 @@
+[Desktop Entry]
+Type=Application
+Name=Digital Signage
+Comment=Launch digital signage dashboard in kiosk mode
+Exec=/home/pi/Sinister-Six-Digital-Signage/start-signage.sh
+Terminal=false
+X-GNOME-Autostart-enabled=true

--- a/start-signage.sh
+++ b/start-signage.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# start-signage.sh — Launch the digital signage app in kiosk mode
+# Intended for Raspberry Pi (Raspbian/Raspberry Pi OS)
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PORT=8080
+URL="http://localhost:${PORT}/index.html"
+
+# --- Start local HTTP server ---
+echo "Starting HTTP server on port ${PORT}..."
+python3 -m http.server "$PORT" --directory "$SCRIPT_DIR" &
+SERVER_PID=$!
+
+# Clean up server on exit
+cleanup() {
+  echo "Shutting down HTTP server (PID ${SERVER_PID})..."
+  kill "$SERVER_PID" 2>/dev/null || true
+}
+trap cleanup EXIT INT TERM
+
+# Give the server a moment to start
+sleep 2
+
+# --- Detect Chromium binary ---
+if command -v chromium-browser >/dev/null 2>&1; then
+  CHROMIUM=chromium-browser
+elif command -v chromium >/dev/null 2>&1; then
+  CHROMIUM=chromium
+else
+  echo "Error: Chromium not found. Install with: sudo apt install chromium-browser"
+  exit 1
+fi
+
+echo "Launching ${CHROMIUM} in kiosk mode..."
+"$CHROMIUM" \
+  --kiosk \
+  --noerrdialogs \
+  --disable-infobars \
+  --disable-restore-session-state \
+  --start-fullscreen \
+  "$URL"


### PR DESCRIPTION
Summary                                                                                                                                
                                                                                                                                         
  - Added start-signage.sh — shell script that launches a Python HTTP server and opens Chromium in kiosk mode, with auto-detection of    
  chromium-browser vs chromium binary and cleanup on exit                                                                                
  - Added signage.desktop — XDG autostart entry for boot-on-start (copy to ~/.config/autostart/)                                         
  - Fixed weather crash when no city is saved in localStorage (JSON.parse(null).city) — now falls back to config.json's weather.location 
  (Denver, CO)                                                                                                                           
  - Reordered app init so loadConfig() runs before fetchWeather(), ensuring the config location is available                             
  - Registered submit button and geolocation checkbox event listeners unconditionally (previously one or the other was skipped based on  
  initial checkbox state)                                                                                                                
  - Unchecked geolocation checkbox by default — fixed-location signage doesn't need it                                                   
  - Added config test asserting weather.location is a non-empty string                                                                   
  - Added Raspberry Pi setup docs to README (install, autostart, screen blanking, weather config)

  Files changed

  - start-signage.sh (new) — kiosk launcher script
  - signage.desktop (new) — autostart desktop entry
  - app.js — config weather fallback, init reorder, event listener fix
  - index.html — uncheck geolocation by default
  - __tests__/config.test.js — new weather location test
  - README.md — Pi setup instructions

  How to test

  1. Lint & format: npx eslint app.js and npx prettier --check app.js index.html — both clean
  2. Tests: npm test — 25/25 passing (including new config test)
  3. Browser: Open with Live Server (or python3 -m http.server 8080) — weather panel should show "Denver, Colorado, US" without typing
  anything or enabling geolocation
  4. On Pi: chmod +x start-signage.sh && ./start-signage.sh — should launch fullscreen kiosk with weather working